### PR TITLE
feat: implement ItemCategory enum with YAML-based keyword configuration

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -6,7 +6,8 @@
       "Bash(poetry run ruff:*)",
       "Bash(poetry run:*)",
       "Bash(make:*)",
-      "Bash(gh issue view:*)"
+      "Bash(gh issue view:*)",
+      "Bash(poetry show:*)"
     ],
     "deny": [],
     "ask": []

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,5 +24,6 @@ repos:
         additional_dependencies:
           - pydantic>=2.5.0
           - types-redis
+          - types-pyyaml
         args: [--ignore-missing-imports]
         exclude: ^(tests/|alembic/)

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -27,5 +27,9 @@
         "tests"
     ],
     "python.testing.unittestEnabled": false,
-    "python.testing.pytestEnabled": true
+    "python.testing.pytestEnabled": true,
+    "sonarlint.connectedMode.project": {
+        "connectionId": "barry47products",
+        "projectKey": "barry47products_is-it-stolen"
+    }
 }

--- a/config/item_categories.yaml
+++ b/config/item_categories.yaml
@@ -1,0 +1,31 @@
+# Item Category Keywords Configuration
+#
+# This file defines keyword mappings for item categories.
+# Keywords are case-insensitive and whitespace is trimmed.
+
+categories:
+  BICYCLE:
+    - bicycle
+    - bike
+    - cycle
+    - mountain bike
+
+  PHONE:
+    - phone
+    - mobile
+    - cellphone
+    - smartphone
+    - iphone
+
+  LAPTOP:
+    - laptop
+    - computer
+    - notebook
+    - macbook
+
+  VEHICLE:
+    - vehicle
+    - car
+    - motorcycle
+    - motorbike
+    - scooter

--- a/docs/is-it-stolen-implementation-guide.md
+++ b/docs/is-it-stolen-implementation-guide.md
@@ -101,11 +101,24 @@ Create `.github/ISSUE_TEMPLATE/feature.md`:
 ````markdown
 ## Implementation Roadmap
 
+### Progress Summary
+
+**Last Updated**: October 2, 2025
+
+**Completed**:
+- ✅ Development environment setup (Poetry, Docker, Alembic, pre-commit hooks)
+- ✅ CI/CD pipeline (GitHub Actions with SonarCloud, Codecov)
+- ✅ Issue #1: Location value object with Haversine distance calculation
+
+**Current Status**: Ready to start Issue #2 (ItemCategory enum)
+
+---
+
 ### Milestone 1: Core Domain (Issues #1-10) - Week 1
 
 Start with the pure domain layer - no external dependencies.
 
-| Issue | Title | Description | Estimate |
+| Issue | Title | Description | Estimate | Status |
 |## Your First Issue: Getting Started
 
 ### Recommended First Issue: #1 - Location Value Object
@@ -249,17 +262,18 @@ After completing the Location value object:
 
 Each issue builds on the previous ones, gradually increasing in complexity while maintaining the same TDD workflow.
 
--------|-------|-------------|----------|
-| #1 | Location value object | Coordinate validation, distance calculation | 2h |
-| #2 | ItemCategory enum | Categories with keyword parsing | 1h |
-| #3 | PhoneNumber value object | E.164 validation | 1h |
-| #4 | StolenItem entity | Aggregate root with validation | 4h |
-| #5 | Domain events | ItemReported, ItemVerified events | 2h |
-| #6 | Matching service | Text similarity algorithm | 3h |
-| #7 | Domain exceptions | Custom domain-specific exceptions | 1h |
-| #8 | Item attributes | Flexible attributes per category | 2h |
-| #9 | Verification rules | Business rules for verification | 2h |
-| #10 | Domain integration tests | Test domain layer together | 2h |
+| Issue | Title                       | Description                                  | Estimate | Status       |
+|-------|-----------------------------|----------------------------------------------|----------|--------------|
+| #1    | Location value object       | Coordinate validation, distance calculation  | 2h       | ✅ COMPLETE  |
+| #2    | ItemCategory enum           | Categories with keyword parsing              | 1h       |              |
+| #3    | PhoneNumber value object    | E.164 validation                             | 1h       |              |
+| #4    | StolenItem entity           | Aggregate root with validation               | 4h       |              |
+| #5    | Domain events               | ItemReported, ItemVerified events            | 2h       |              |
+| #6    | Matching service            | Text similarity algorithm                    | 3h       |              |
+| #7    | Domain exceptions           | Custom domain-specific exceptions            | 1h       |              |
+| #8    | Item attributes             | Flexible attributes per category             | 2h       |              |
+| #9    | Verification rules          | Business rules for verification              | 2h       |              |
+| #10   | Domain integration tests    | Test domain layer together                   | 2h       |              |
 
 ### Milestone 2: Infrastructure (Issues #11-20) - Week 2
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ celery = "^5.3.4"
 httpx = "^0.25.2"
 tenacity = "^8.2.3"
 sentry-sdk = {extras = ["fastapi"], version = "^1.38.0"}
+pyyaml = "^6.0.1"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.4.3"
@@ -35,6 +36,8 @@ mypy = "^1.7.1"
 pre-commit = "^3.5.0"
 ipython = "^8.18.1"
 ipdb = "^0.13.13"
+types-pyyaml = "^6.0.12"
+pyyaml = "^6.0.3"
 
 [build-system]
 requires = ["poetry-core"]

--- a/src/domain/value_objects/item_category.py
+++ b/src/domain/value_objects/item_category.py
@@ -1,0 +1,68 @@
+"""ItemCategory enum for categorizing stolen items."""
+
+from enum import Enum
+
+# Module-level keyword mappings (configured at startup)
+_keyword_mappings: dict[str, "ItemCategory"] = {}
+
+
+class ItemCategory(str, Enum):
+    """Categories for stolen items with keyword matching."""
+
+    BICYCLE = "bicycle"
+    PHONE = "phone"
+    LAPTOP = "laptop"
+    VEHICLE = "vehicle"
+
+    @classmethod
+    def set_keywords(cls, category_keywords: dict[str, list[str]]) -> None:
+        """Configure keyword mappings for category parsing.
+
+        This method should be called at application startup to configure
+        keyword mappings from the configuration file.
+
+        Args:
+            category_keywords: Dictionary mapping category names to keyword lists
+                Example: {"BICYCLE": ["bike", "cycle"], "PHONE": ["mobile"]}
+
+        Raises:
+            ValueError: If category name is invalid or keywords are empty
+        """
+        global _keyword_mappings
+        _keyword_mappings = {}
+
+        for category_name, keywords in category_keywords.items():
+            try:
+                category = cls[category_name.upper()]
+            except KeyError as error:
+                raise ValueError(f"Invalid category name: {category_name}") from error
+
+            if not keywords:
+                raise ValueError(f"Keywords for {category_name} cannot be empty")
+
+            for keyword in keywords:
+                normalized_keyword = keyword.strip().lower()
+                _keyword_mappings[normalized_keyword] = category
+
+    @classmethod
+    def from_user_input(cls, user_input: str) -> "ItemCategory":
+        """Parse category from user input with keyword matching.
+
+        Args:
+            user_input: User-provided category name or keyword
+
+        Returns:
+            Matching ItemCategory enum value
+
+        Raises:
+            ValueError: If no matching category found
+        """
+        normalized = user_input.strip().lower()
+
+        if not normalized:
+            raise ValueError("Unknown item category: empty string")
+
+        if normalized in _keyword_mappings:
+            return _keyword_mappings[normalized]
+
+        raise ValueError(f"Unknown item category: {user_input}")

--- a/src/infrastructure/config/__init__.py
+++ b/src/infrastructure/config/__init__.py
@@ -1,0 +1,5 @@
+"""Configuration loading infrastructure."""
+
+from src.infrastructure.config.category_keywords import load_category_keywords
+
+__all__ = ["load_category_keywords"]

--- a/src/infrastructure/config/category_keywords.py
+++ b/src/infrastructure/config/category_keywords.py
@@ -1,0 +1,68 @@
+"""Category keywords configuration loader."""
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+def load_category_keywords() -> dict[str, list[str]]:
+    """Load item category keywords from YAML configuration.
+
+    Returns:
+        Dictionary mapping category names to lists of keywords
+
+    Raises:
+        FileNotFoundError: If config file doesn't exist
+        ValueError: If config format is invalid
+    """
+    config_path = _get_config_path()
+
+    if not config_path.exists():
+        raise FileNotFoundError(f"Configuration file not found: {config_path}")
+
+    with config_path.open("r") as file:
+        data: dict[str, Any] = yaml.safe_load(file)
+
+    if "categories" not in data:
+        raise ValueError("Invalid config: missing 'categories' key")
+
+    categories = data["categories"]
+    if not isinstance(categories, dict):
+        raise ValueError("Invalid config: 'categories' must be a dictionary")
+
+    _validate_keywords(categories)
+
+    return categories
+
+
+def _get_config_path() -> Path:
+    """Get path to category keywords configuration file."""
+    return (
+        Path(__file__).parent.parent.parent.parent / "config" / "item_categories.yaml"
+    )
+
+
+def _validate_keywords(categories: dict[str, Any]) -> None:
+    """Validate keyword structure.
+
+    Args:
+        categories: Category keyword mappings to validate
+
+    Raises:
+        ValueError: If keywords structure is invalid
+    """
+    for category_name, keywords in categories.items():
+        if not isinstance(keywords, list):
+            raise ValueError(
+                f"Invalid config: keywords for '{category_name}' must be a list"
+            )
+
+        if not keywords:
+            raise ValueError(f"Invalid config: '{category_name}' has no keywords")
+
+        for keyword in keywords:
+            if not isinstance(keyword, str):
+                raise ValueError(
+                    f"Invalid config: keyword in '{category_name}' must be a string"
+                )

--- a/src/presentation/api/app.py
+++ b/src/presentation/api/app.py
@@ -1,5 +1,12 @@
 """FastAPI application entry point."""
+
 from fastapi import FastAPI
+
+from src.domain.value_objects.item_category import ItemCategory
+from src.infrastructure.config import load_category_keywords
+
+# Load configuration at startup
+ItemCategory.set_keywords(load_category_keywords())
 
 app = FastAPI(
     title="Is It Stolen API",

--- a/tests/unit/domain/value_objects/test_item_category.py
+++ b/tests/unit/domain/value_objects/test_item_category.py
@@ -1,0 +1,95 @@
+"""Tests for ItemCategory enum."""
+
+import pytest
+
+from src.domain.value_objects.item_category import ItemCategory
+
+pytestmark = pytest.mark.unit
+
+
+class TestItemCategory:
+    """Test suite for ItemCategory enum."""
+
+    @pytest.fixture(autouse=True)
+    def setup_keywords(self) -> None:
+        """Set up test keyword mappings before each test."""
+        test_keywords = {
+            "BICYCLE": ["bicycle", "bike", "cycle", "mountain bike"],
+            "PHONE": ["phone", "mobile", "cellphone", "smartphone", "iphone"],
+            "LAPTOP": ["laptop", "computer", "notebook", "macbook"],
+            "VEHICLE": ["vehicle", "car", "motorcycle", "motorbike", "scooter"],
+        }
+        ItemCategory.set_keywords(test_keywords)
+
+    def test_creates_category_from_enum_value(self) -> None:
+        """Should create category from valid enum value."""
+        category = ItemCategory.BICYCLE
+        assert category == ItemCategory.BICYCLE
+
+    def test_has_all_required_categories(self) -> None:
+        """Should have all required category types."""
+        assert ItemCategory.BICYCLE
+        assert ItemCategory.PHONE
+        assert ItemCategory.LAPTOP
+        assert ItemCategory.VEHICLE
+
+    def test_parses_exact_category_name(self) -> None:
+        """Should parse exact category name."""
+        category = ItemCategory.from_user_input("bicycle")
+        assert category == ItemCategory.BICYCLE
+
+    def test_parses_category_name_case_insensitive(self) -> None:
+        """Should parse category name case-insensitively."""
+        assert ItemCategory.from_user_input("BICYCLE") == ItemCategory.BICYCLE
+        assert ItemCategory.from_user_input("BiCyCLe") == ItemCategory.BICYCLE
+
+    def test_parses_bicycle_keywords(self) -> None:
+        """Should parse bicycle keywords."""
+        assert ItemCategory.from_user_input("bike") == ItemCategory.BICYCLE
+        assert ItemCategory.from_user_input("cycle") == ItemCategory.BICYCLE
+        assert ItemCategory.from_user_input("mountain bike") == ItemCategory.BICYCLE
+
+    def test_parses_phone_keywords(self) -> None:
+        """Should parse phone keywords."""
+        assert ItemCategory.from_user_input("mobile") == ItemCategory.PHONE
+        assert ItemCategory.from_user_input("cellphone") == ItemCategory.PHONE
+        assert ItemCategory.from_user_input("smartphone") == ItemCategory.PHONE
+        assert ItemCategory.from_user_input("iphone") == ItemCategory.PHONE
+
+    def test_parses_laptop_keywords(self) -> None:
+        """Should parse laptop keywords."""
+        assert ItemCategory.from_user_input("computer") == ItemCategory.LAPTOP
+        assert ItemCategory.from_user_input("notebook") == ItemCategory.LAPTOP
+        assert ItemCategory.from_user_input("macbook") == ItemCategory.LAPTOP
+
+    def test_parses_vehicle_keywords(self) -> None:
+        """Should parse vehicle keywords."""
+        assert ItemCategory.from_user_input("car") == ItemCategory.VEHICLE
+        assert ItemCategory.from_user_input("motorcycle") == ItemCategory.VEHICLE
+        assert ItemCategory.from_user_input("motorbike") == ItemCategory.VEHICLE
+        assert ItemCategory.from_user_input("scooter") == ItemCategory.VEHICLE
+
+    def test_raises_error_for_invalid_category(self) -> None:
+        """Should raise ValueError for invalid category."""
+        with pytest.raises(ValueError, match="Unknown item category"):
+            ItemCategory.from_user_input("invalid")
+
+    def test_raises_error_for_empty_string(self) -> None:
+        """Should raise ValueError for empty string."""
+        with pytest.raises(ValueError, match="Unknown item category"):
+            ItemCategory.from_user_input("")
+
+    def test_keyword_matching_with_whitespace(self) -> None:
+        """Should handle whitespace in keywords."""
+        assert ItemCategory.from_user_input("  bike  ") == ItemCategory.BICYCLE
+        assert ItemCategory.from_user_input("\tmobile\n") == ItemCategory.PHONE
+
+    def test_set_keywords_validates_category_name(self) -> None:
+        """Should raise ValueError for invalid category name."""
+        with pytest.raises(ValueError, match="Invalid category name"):
+            ItemCategory.set_keywords({"INVALID": ["keyword"]})
+
+    def test_set_keywords_validates_empty_keywords(self) -> None:
+        """Should raise ValueError for empty keyword list."""
+        with pytest.raises(ValueError, match="cannot be empty"):
+            ItemCategory.set_keywords({"BICYCLE": []})

--- a/tests/unit/infrastructure/__init__.py
+++ b/tests/unit/infrastructure/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for infrastructure layer."""

--- a/tests/unit/infrastructure/test_category_keywords_loader.py
+++ b/tests/unit/infrastructure/test_category_keywords_loader.py
@@ -1,0 +1,102 @@
+"""Tests for category keywords configuration loader."""
+
+from pathlib import Path
+from unittest.mock import mock_open, patch
+
+import pytest
+
+from src.infrastructure.config.category_keywords import (
+    _validate_keywords,
+    load_category_keywords,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class TestLoadCategoryKeywords:
+    """Test suite for load_category_keywords function."""
+
+    def test_loads_keywords_from_yaml_file(self) -> None:
+        """Should load keywords from YAML configuration file."""
+        keywords = load_category_keywords()
+
+        assert isinstance(keywords, dict)
+        assert "BICYCLE" in keywords
+        assert "PHONE" in keywords
+        assert "LAPTOP" in keywords
+        assert "VEHICLE" in keywords
+
+    def test_bicycle_keywords_match_config(self) -> None:
+        """Should load correct bicycle keywords."""
+        keywords = load_category_keywords()
+
+        assert "bicycle" in keywords["BICYCLE"]
+        assert "bike" in keywords["BICYCLE"]
+        assert "cycle" in keywords["BICYCLE"]
+
+    def test_raises_error_when_file_not_found(self) -> None:
+        """Should raise FileNotFoundError when config file doesn't exist."""
+        with (
+            patch("pathlib.Path.exists", return_value=False),
+            pytest.raises(FileNotFoundError, match="Configuration file not found"),
+        ):
+            load_category_keywords()
+
+    def test_raises_error_when_categories_key_missing(self) -> None:
+        """Should raise ValueError when 'categories' key is missing."""
+        yaml_content = "invalid: data"
+        mock_path = Path("/fake/path/config/item_categories.yaml")
+
+        with (
+            patch(
+                "src.infrastructure.config.category_keywords._get_config_path",
+                return_value=mock_path,
+            ),
+            patch("pathlib.Path.exists", return_value=True),
+            patch("pathlib.Path.open", mock_open(read_data=yaml_content)),
+            pytest.raises(ValueError, match="missing 'categories' key"),
+        ):
+            load_category_keywords()
+
+    def test_raises_error_when_categories_not_dict(self) -> None:
+        """Should raise ValueError when 'categories' is not a dictionary."""
+        yaml_content = "categories: not_a_dict"
+        mock_path = Path("/fake/path/config/item_categories.yaml")
+
+        with (
+            patch(
+                "src.infrastructure.config.category_keywords._get_config_path",
+                return_value=mock_path,
+            ),
+            patch("pathlib.Path.exists", return_value=True),
+            patch("pathlib.Path.open", mock_open(read_data=yaml_content)),
+            pytest.raises(ValueError, match="must be a dictionary"),
+        ):
+            load_category_keywords()
+
+
+class TestValidateKeywords:
+    """Test suite for _validate_keywords function."""
+
+    def test_validates_keywords_must_be_list(self) -> None:
+        """Should raise ValueError when keywords is not a list."""
+        with pytest.raises(ValueError, match="must be a list"):
+            _validate_keywords({"BICYCLE": "not_a_list"})
+
+    def test_validates_keywords_not_empty(self) -> None:
+        """Should raise ValueError when keyword list is empty."""
+        with pytest.raises(ValueError, match="has no keywords"):
+            _validate_keywords({"BICYCLE": []})
+
+    def test_validates_keyword_is_string(self) -> None:
+        """Should raise ValueError when keyword is not a string."""
+        with pytest.raises(ValueError, match="must be a string"):
+            _validate_keywords({"BICYCLE": [123]})
+
+    def test_accepts_valid_keywords(self) -> None:
+        """Should not raise error for valid keyword structure."""
+        valid_keywords = {
+            "BICYCLE": ["bike", "cycle"],
+            "PHONE": ["mobile", "phone"],
+        }
+        _validate_keywords(valid_keywords)  # Should not raise


### PR DESCRIPTION
## Summary

Implements the ItemCategory enum as specified in Issue #2 with YAML-based keyword configuration.

**Key Implementation**: Keywords are stored in `config/item_categories.yaml` instead of hardcoded in the source, allowing easy modification without code changes while maintaining domain purity through dependency injection.

### Features Implemented
- ✅ Enum with BICYCLE, PHONE, LAPTOP, VEHICLE categories
- ✅ Case-insensitive keyword matching
- ✅ YAML-based configuration (externalized keywords)
- ✅ Dependency injection pattern (domain stays pure)
- ✅ Validation on configuration load

### Architecture

**Domain Layer** (Pure - No I/O):
- `ItemCategory` enum with `set_keywords()` classmethod
- Module-level keyword mappings configured at startup
- `from_user_input()` parses keywords with validation

**Infrastructure Layer**:
- `load_category_keywords()` reads YAML file
- Validates structure, types, empty checks
- Returns dict ready for domain injection

**Startup Configuration**:
- `app.py` loads YAML and calls `ItemCategory.set_keywords()`
- Configuration happens once at application startup

### Test Coverage

**Domain Tests** (13 tests):
- Enum creation and category validation
- Keyword parsing (exact match, case-insensitive, whitespace)
- All category keywords tested
- Error handling (invalid category, empty string)
- Configuration validation (invalid category name, empty keywords)

**Infrastructure Tests** (9 tests):
- YAML file loading with real config
- Error handling (file not found, invalid structure)
- Validation logic (keyword types, empty lists)

**Result**: 100% code coverage (39 tests passing)

### Dependencies Added

```toml
pyyaml = "^6.0.3"              # Production: YAML parsing
types-pyyaml = "^6.0.12"       # Development: MyPy type stubs
```

**Pre-commit update**: Added `types-pyyaml` to MyPy hook's `additional_dependencies` to fix isolated environment type checking.

### Configuration File

`config/item_categories.yaml`:
```yaml
categories:
  BICYCLE:
    - bicycle
    - bike
    - cycle
    - mountain bike
  
  PHONE:
    - phone
    - mobile
    - cellphone
    - smartphone
    - iphone
  
  # ... etc
```

Keywords are now easily editable without touching code!

## Test Plan

- [x] All 39 unit tests pass with 100% coverage
- [x] Linting passes (Ruff)
- [x] Type checking passes (MyPy with types-pyyaml)
- [x] Formatting passes (Ruff format)
- [x] Pre-commit hooks pass (including MyPy in isolated env)

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)