### PR TITLE
feat: implement WhatsApp Cloud API client with retry logic

### DIFF
--- a/docs/is-it-stolen-implementation-guide.md
+++ b/docs/is-it-stolen-implementation-guide.md
@@ -296,7 +296,7 @@ Build the infrastructure to support the domain.
 | #11   | Database setup       | PostgreSQL with PostGIS             | 2h       | ✅ COMPLETE |
 | #12   | SQLAlchemy models    | Database models with GeoAlchemy2    | 3h       | ✅ COMPLETE |
 | #13   | Repository pattern   | StolenItemRepository implementation | 3h       | ✅ COMPLETE |
-| #14   | WhatsApp client      | REST API client with retry logic    | 4h       |             |
+| #14   | WhatsApp client      | REST API client with retry logic    | 4h       | ✅ COMPLETE |
 | #15   | Webhook handler      | Parse and validate webhooks         | 3h       |             |
 | #16   | Redis setup          | Cache and session management        | 2h       |             |
 | #17   | Event bus            | Publish domain events               | 2h       |             |

--- a/src/infrastructure/persistence/repositories/postgres_stolen_item_repository.py
+++ b/src/infrastructure/persistence/repositories/postgres_stolen_item_repository.py
@@ -75,6 +75,11 @@ class PostgresStolenItemRepository(IStolenItemRepository):
 
         Returns:
             Domain entity
+
+        Note:
+            Type ignores are required due to SQLAlchemy's descriptor pattern.
+            At the class level, attributes are Column[T] descriptors, but at
+            runtime (instance level), they are actual values of type T.
         """
         location = Location(
             latitude=model.latitude,  # type: ignore[arg-type]

--- a/src/infrastructure/whatsapp/__init__.py
+++ b/src/infrastructure/whatsapp/__init__.py
@@ -1,0 +1,17 @@
+"""WhatsApp infrastructure components."""
+
+from src.infrastructure.whatsapp.client import WhatsAppClient
+from src.infrastructure.whatsapp.exceptions import (
+    WhatsAppAPIError,
+    WhatsAppError,
+    WhatsAppMediaError,
+    WhatsAppRateLimitError,
+)
+
+__all__ = [
+    "WhatsAppAPIError",
+    "WhatsAppClient",
+    "WhatsAppError",
+    "WhatsAppMediaError",
+    "WhatsAppRateLimitError",
+]

--- a/src/infrastructure/whatsapp/client.py
+++ b/src/infrastructure/whatsapp/client.py
@@ -1,0 +1,256 @@
+"""WhatsApp Cloud API client."""
+
+import asyncio
+from typing import Any
+
+import httpx
+
+from src.infrastructure.whatsapp.exceptions import (
+    WhatsAppAPIError,
+    WhatsAppMediaError,
+    WhatsAppRateLimitError,
+)
+
+WHATSAPP_API_VERSION = "v21.0"
+WHATSAPP_BASE_URL = "https://graph.facebook.com"
+DEFAULT_TIMEOUT = 30.0
+DEFAULT_MAX_RETRIES = 3
+INITIAL_BACKOFF_SECONDS = 1.0
+BACKOFF_MULTIPLIER = 2.0
+
+
+class WhatsAppClient:
+    """WhatsApp Cloud API client with retry logic.
+
+    Provides methods to send messages, templates, media, and download
+    media from WhatsApp Business Cloud API.
+    """
+
+    def __init__(
+        self,
+        phone_number_id: str,
+        access_token: str,
+        max_retries: int = DEFAULT_MAX_RETRIES,
+        timeout: float = DEFAULT_TIMEOUT,
+    ) -> None:
+        """Initialize WhatsApp client.
+
+        Args:
+            phone_number_id: WhatsApp Business phone number ID
+            access_token: WhatsApp Business API access token
+            max_retries: Maximum number of retries for rate limits
+            timeout: Request timeout in seconds
+        """
+        self.phone_number_id = phone_number_id
+        self.access_token = access_token
+        self.max_retries = max_retries
+        self.timeout = timeout
+        self.base_url = f"{WHATSAPP_BASE_URL}/{WHATSAPP_API_VERSION}"
+
+    async def send_text_message(self, to: str, text: str) -> str:
+        """Send text message to recipient.
+
+        Args:
+            to: Recipient phone number in E.164 format
+            text: Message text
+
+        Returns:
+            Message ID from WhatsApp
+
+        Raises:
+            WhatsAppAPIError: If API returns an error
+            WhatsAppRateLimitError: If rate limit exceeded after retries
+        """
+        payload = {
+            "messaging_product": "whatsapp",
+            "recipient_type": "individual",
+            "to": to,
+            "type": "text",
+            "text": {"body": text},
+        }
+
+        response = await self._send_message(payload)
+        return str(response["messages"][0]["id"])
+
+    async def send_template_message(
+        self,
+        to: str,
+        template_name: str,
+        language_code: str,
+        variables: list[str] | None = None,
+    ) -> str:
+        """Send template message with variables.
+
+        Args:
+            to: Recipient phone number in E.164 format
+            template_name: Name of approved template
+            language_code: Language code (e.g., "en", "en_US")
+            variables: List of variable values for template
+
+        Returns:
+            Message ID from WhatsApp
+
+        Raises:
+            WhatsAppAPIError: If API returns an error
+            WhatsAppRateLimitError: If rate limit exceeded after retries
+        """
+        components = []
+        if variables:
+            parameters = [{"type": "text", "text": var} for var in variables]
+            components.append({"type": "body", "parameters": parameters})
+
+        payload = {
+            "messaging_product": "whatsapp",
+            "recipient_type": "individual",
+            "to": to,
+            "type": "template",
+            "template": {
+                "name": template_name,
+                "language": {"code": language_code},
+                "components": components,
+            },
+        }
+
+        response = await self._send_message(payload)
+        return str(response["messages"][0]["id"])
+
+    async def send_image(
+        self, to: str, image_url: str, caption: str | None = None
+    ) -> str:
+        """Send image message.
+
+        Args:
+            to: Recipient phone number in E.164 format
+            image_url: URL of image to send
+            caption: Optional image caption
+
+        Returns:
+            Message ID from WhatsApp
+
+        Raises:
+            WhatsAppAPIError: If API returns an error
+            WhatsAppRateLimitError: If rate limit exceeded after retries
+        """
+        image_data: dict[str, Any] = {"link": image_url}
+        if caption:
+            image_data["caption"] = caption
+
+        payload = {
+            "messaging_product": "whatsapp",
+            "recipient_type": "individual",
+            "to": to,
+            "type": "image",
+            "image": image_data,
+        }
+
+        response = await self._send_message(payload)
+        return str(response["messages"][0]["id"])
+
+    async def download_media(self, media_id: str) -> bytes:
+        """Download media from WhatsApp.
+
+        Args:
+            media_id: Media ID from WhatsApp message
+
+        Returns:
+            Media content as bytes
+
+        Raises:
+            WhatsAppMediaError: If media download fails
+        """
+        try:
+            # Step 1: Get media URL
+            url = f"{self.base_url}/{media_id}"
+            headers = {"Authorization": f"Bearer {self.access_token}"}
+
+            async with httpx.AsyncClient(timeout=self.timeout) as client:
+                response = await client.get(url, headers=headers)
+
+                if response.status_code != 200:
+                    raise WhatsAppMediaError(
+                        f"Failed to get media URL: {response.status_code}"
+                    )
+
+                media_info = response.json()
+                media_url = media_info["url"]
+
+                # Step 2: Download media content
+                media_response = await client.get(media_url, headers=headers)
+
+                if media_response.status_code != 200:
+                    raise WhatsAppMediaError(
+                        f"Failed to download media: {media_response.status_code}"
+                    )
+
+                content: bytes = media_response.content
+                return content
+
+        except httpx.HTTPError as e:
+            raise WhatsAppMediaError(f"HTTP error downloading media: {e}") from e
+        except KeyError as e:
+            raise WhatsAppMediaError(f"Invalid media response: {e}") from e
+
+    async def _send_message(self, payload: dict[str, Any]) -> dict[str, Any]:
+        """Send message with retry logic.
+
+        Args:
+            payload: Message payload
+
+        Returns:
+            API response JSON
+
+        Raises:
+            WhatsAppAPIError: If API returns an error
+            WhatsAppRateLimitError: If rate limit exceeded after retries
+        """
+        url = f"{self.base_url}/{self.phone_number_id}/messages"
+        headers = {
+            "Authorization": f"Bearer {self.access_token}",
+            "Content-Type": "application/json",
+        }
+
+        last_error: Exception | None = None
+
+        for attempt in range(self.max_retries + 1):
+            try:
+                async with httpx.AsyncClient(timeout=self.timeout) as client:
+                    response = await client.post(url, headers=headers, json=payload)
+
+                    # Handle rate limiting with exponential backoff
+                    if response.status_code == 429:
+                        if attempt < self.max_retries:
+                            backoff = INITIAL_BACKOFF_SECONDS * (
+                                BACKOFF_MULTIPLIER**attempt
+                            )
+                            await asyncio.sleep(backoff)
+                            continue
+
+                        # Max retries exceeded
+                        error_data = response.json().get("error", {})
+                        raise WhatsAppRateLimitError(
+                            error_data.get("message", "Too Many Requests")
+                        )
+
+                    # Handle other errors
+                    if response.status_code != 200:
+                        error_data = response.json().get("error", {})
+                        raise WhatsAppAPIError(
+                            message=error_data.get("message", "Unknown error"),
+                            error_code=error_data.get("code"),
+                        )
+
+                    result: dict[str, Any] = response.json()
+                    return result
+
+            except (httpx.HTTPError, WhatsAppAPIError, WhatsAppRateLimitError) as e:
+                last_error = e
+                if isinstance(e, WhatsAppRateLimitError) and attempt < self.max_retries:
+                    backoff = INITIAL_BACKOFF_SECONDS * (BACKOFF_MULTIPLIER**attempt)
+                    await asyncio.sleep(backoff)
+                    continue
+                raise
+
+        # Should never reach here, but just in case
+        if last_error:
+            raise last_error
+        raise WhatsAppAPIError("Unknown error occurred")

--- a/src/infrastructure/whatsapp/client.py
+++ b/src/infrastructure/whatsapp/client.py
@@ -209,8 +209,6 @@ class WhatsAppClient:
             "Content-Type": "application/json",
         }
 
-        last_error: Exception | None = None
-
         for attempt in range(self.max_retries + 1):
             try:
                 async with httpx.AsyncClient(timeout=self.timeout) as client:
@@ -243,14 +241,11 @@ class WhatsAppClient:
                     return result
 
             except (httpx.HTTPError, WhatsAppAPIError, WhatsAppRateLimitError) as e:
-                last_error = e
                 if isinstance(e, WhatsAppRateLimitError) and attempt < self.max_retries:
                     backoff = INITIAL_BACKOFF_SECONDS * (BACKOFF_MULTIPLIER**attempt)
                     await asyncio.sleep(backoff)
                     continue
                 raise
 
-        # Should never reach here, but just in case
-        if last_error:
-            raise last_error
-        raise WhatsAppAPIError("Unknown error occurred")
+        # This line is unreachable but satisfies mypy's return checking
+        raise WhatsAppAPIError("Unknown error occurred")  # pragma: no cover

--- a/src/infrastructure/whatsapp/exceptions.py
+++ b/src/infrastructure/whatsapp/exceptions.py
@@ -1,0 +1,33 @@
+"""WhatsApp API exceptions."""
+
+
+class WhatsAppError(Exception):
+    """Base exception for WhatsApp-related errors."""
+
+    pass
+
+
+class WhatsAppAPIError(WhatsAppError):
+    """Raised when WhatsApp API returns an error response."""
+
+    def __init__(self, message: str, error_code: int | None = None) -> None:
+        """Initialize WhatsApp API error.
+
+        Args:
+            message: Error message from API
+            error_code: Error code from API
+        """
+        super().__init__(message)
+        self.error_code = error_code
+
+
+class WhatsAppRateLimitError(WhatsAppError):
+    """Raised when WhatsApp API rate limit is exceeded."""
+
+    pass
+
+
+class WhatsAppMediaError(WhatsAppError):
+    """Raised when media download or upload fails."""
+
+    pass

--- a/tests/integration/infrastructure/test_models.py
+++ b/tests/integration/infrastructure/test_models.py
@@ -132,8 +132,10 @@ class TestStolenItemModel:
                 .filter(StolenItemModel.report_id == item_id)
                 .first()
             )
-            item.status = ItemStatus.RECOVERED.value
-            item.updated_at = datetime.now(UTC)
+            assert item is not None
+            # SQLAlchemy descriptor pattern: class attr is Column, instance attr is actual value
+            item.status = ItemStatus.RECOVERED.value  # type: ignore[assignment]
+            item.updated_at = datetime.now(UTC)  # type: ignore[assignment]
             db.commit()
 
         # Assert
@@ -143,6 +145,7 @@ class TestStolenItemModel:
                 .filter(StolenItemModel.report_id == item_id)
                 .first()
             )
+            assert updated_item is not None
             assert updated_item.status == ItemStatus.RECOVERED.value
 
     def test_stores_optional_item_fields(self) -> None:
@@ -180,6 +183,7 @@ class TestStolenItemModel:
                 .filter(StolenItemModel.report_id == item_id)
                 .first()
             )
+            assert retrieved_item is not None
             assert retrieved_item.brand == "Trek"
             assert retrieved_item.model == "X-Caliber 9"
             assert retrieved_item.serial_number == "WTU123456789"
@@ -219,6 +223,7 @@ class TestStolenItemModel:
                 .filter(StolenItemModel.report_id == item_id)
                 .first()
             )
+            assert retrieved_item is not None
             assert retrieved_item.police_reference == "MET/2024/123456"
             assert retrieved_item.verified_at is not None
 

--- a/tests/integration/infrastructure/test_postgres_stolen_item_repository.py
+++ b/tests/integration/infrastructure/test_postgres_stolen_item_repository.py
@@ -385,11 +385,11 @@ class TestPostgresStolenItemRepository:
             updated_at=datetime.now(UTC),
         )
 
-        def failing_db():
+        def failing_db():  # type: ignore[no-untyped-def]
             # Force a constraint violation or connection error
             raise Exception("Database connection failed")
 
-        repository._get_db = failing_db
+        repository._get_db = failing_db  # type: ignore[method-assign]
 
         # Act & Assert
         with pytest.raises(RepositoryError) as exc_info:
@@ -409,7 +409,7 @@ class TestPostgresStolenItemRepository:
             item_type=ItemCategory.BICYCLE,
             description="Bike stolen somewhere",
             stolen_date=datetime(2025, 10, 1, tzinfo=UTC),
-            location=None,  # No location
+            location=None,  # type: ignore[arg-type]  # Testing defensive null handling
             status=ItemStatus.ACTIVE,
             created_at=datetime.now(UTC),
             updated_at=datetime.now(UTC),

--- a/tests/unit/infrastructure/test_whatsapp_client.py
+++ b/tests/unit/infrastructure/test_whatsapp_client.py
@@ -1,0 +1,313 @@
+"""Unit tests for WhatsApp Cloud API client."""
+
+from unittest.mock import AsyncMock, Mock, patch
+
+import httpx
+import pytest
+
+from src.infrastructure.whatsapp.client import WhatsAppClient
+from src.infrastructure.whatsapp.exceptions import (
+    WhatsAppAPIError,
+    WhatsAppMediaError,
+    WhatsAppRateLimitError,
+)
+
+
+class TestWhatsAppClient:
+    """Test WhatsApp client."""
+
+    @pytest.fixture
+    def client(self) -> WhatsAppClient:
+        """Create WhatsApp client instance."""
+        return WhatsAppClient(
+            phone_number_id="123456789",
+            access_token="test_token",
+        )
+
+    async def test_sends_text_message(self, client: WhatsAppClient) -> None:
+        """Should send text message to recipient."""
+        # Arrange
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "messaging_product": "whatsapp",
+            "contacts": [{"input": "+447911123456", "wa_id": "447911123456"}],
+            "messages": [{"id": "wamid.test123"}],
+        }
+
+        with patch("httpx.AsyncClient.post", new_callable=AsyncMock) as mock_post:
+            mock_post.return_value = mock_response
+
+            # Act
+            message_id = await client.send_text_message(
+                to="+447911123456",
+                text="Hello from Is It Stolen!",
+            )
+
+            # Assert
+            assert message_id == "wamid.test123"
+            mock_post.assert_called_once()
+            call_args = mock_post.call_args
+            assert call_args.kwargs["json"]["to"] == "+447911123456"
+            assert call_args.kwargs["json"]["type"] == "text"
+            assert (
+                call_args.kwargs["json"]["text"]["body"] == "Hello from Is It Stolen!"
+            )
+
+    async def test_sends_template_message(self, client: WhatsAppClient) -> None:
+        """Should send template message with variables."""
+        # Arrange
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "messaging_product": "whatsapp",
+            "contacts": [{"input": "+447911123456", "wa_id": "447911123456"}],
+            "messages": [{"id": "wamid.template123"}],
+        }
+
+        with patch("httpx.AsyncClient.post", new_callable=AsyncMock) as mock_post:
+            mock_post.return_value = mock_response
+
+            # Act
+            message_id = await client.send_template_message(
+                to="+447911123456",
+                template_name="item_reported",
+                language_code="en",
+                variables=["Bicycle", "London"],
+            )
+
+            # Assert
+            assert message_id == "wamid.template123"
+            mock_post.assert_called_once()
+            call_args = mock_post.call_args
+            assert call_args.kwargs["json"]["to"] == "+447911123456"
+            assert call_args.kwargs["json"]["type"] == "template"
+            assert call_args.kwargs["json"]["template"]["name"] == "item_reported"
+
+    async def test_sends_image_message(self, client: WhatsAppClient) -> None:
+        """Should send image message."""
+        # Arrange
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "messaging_product": "whatsapp",
+            "contacts": [{"input": "+447911123456", "wa_id": "447911123456"}],
+            "messages": [{"id": "wamid.image123"}],
+        }
+
+        with patch("httpx.AsyncClient.post", new_callable=AsyncMock) as mock_post:
+            mock_post.return_value = mock_response
+
+            # Act
+            message_id = await client.send_image(
+                to="+447911123456",
+                image_url="https://example.com/bike.jpg",
+                caption="Stolen bike photo",
+            )
+
+            # Assert
+            assert message_id == "wamid.image123"
+            mock_post.assert_called_once()
+            call_args = mock_post.call_args
+            assert call_args.kwargs["json"]["to"] == "+447911123456"
+            assert call_args.kwargs["json"]["type"] == "image"
+            assert (
+                call_args.kwargs["json"]["image"]["link"]
+                == "https://example.com/bike.jpg"
+            )
+            assert call_args.kwargs["json"]["image"]["caption"] == "Stolen bike photo"
+
+    async def test_downloads_media(self, client: WhatsAppClient) -> None:
+        """Should download media from WhatsApp."""
+        # Arrange
+        media_id = "media123"
+        media_url = "https://lookaside.fbsbx.com/whatsapp_business/attachments/"
+        media_content = b"fake_image_data"
+
+        # Mock getting media URL
+        mock_url_response = Mock()
+        mock_url_response.status_code = 200
+        mock_url_response.json.return_value = {
+            "messaging_product": "whatsapp",
+            "url": media_url,
+            "mime_type": "image/jpeg",
+            "sha256": "test_hash",
+            "file_size": len(media_content),
+        }
+
+        # Mock downloading media content
+        mock_content_response = Mock()
+        mock_content_response.status_code = 200
+        mock_content_response.content = media_content
+
+        with patch("httpx.AsyncClient.get", new_callable=AsyncMock) as mock_get:
+            mock_get.side_effect = [mock_url_response, mock_content_response]
+
+            # Act
+            content = await client.download_media(media_id)
+
+            # Assert
+            assert content == media_content
+            assert mock_get.call_count == 2
+
+    async def test_retries_on_rate_limit(self, client: WhatsAppClient) -> None:
+        """Should retry with exponential backoff on 429 errors."""
+        # Arrange
+        mock_rate_limit_response = Mock()
+        mock_rate_limit_response.status_code = 429
+        mock_rate_limit_response.json.return_value = {
+            "error": {
+                "message": "Too Many Requests",
+                "type": "OAuthException",
+                "code": 4,
+                "error_subcode": 2494055,
+                "fbtrace_id": "test123",
+            }
+        }
+
+        mock_success_response = Mock()
+        mock_success_response.status_code = 200
+        mock_success_response.json.return_value = {
+            "messaging_product": "whatsapp",
+            "contacts": [{"input": "+447911123456", "wa_id": "447911123456"}],
+            "messages": [{"id": "wamid.success"}],
+        }
+
+        with patch("httpx.AsyncClient.post", new_callable=AsyncMock) as mock_post:
+            # First call returns 429, second call succeeds
+            mock_post.side_effect = [mock_rate_limit_response, mock_success_response]
+
+            with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+                # Act
+                message_id = await client.send_text_message(
+                    to="+447911123456",
+                    text="Test retry",
+                )
+
+                # Assert
+                assert message_id == "wamid.success"
+                assert mock_post.call_count == 2
+                mock_sleep.assert_called_once()  # Should have slept for backoff
+
+    async def test_raises_error_on_api_failure(self, client: WhatsAppClient) -> None:
+        """Should raise WhatsAppAPIError on API errors."""
+        # Arrange
+        mock_error_response = Mock()
+        mock_error_response.status_code = 400
+        mock_error_response.json.return_value = {
+            "error": {
+                "message": "Invalid phone number",
+                "type": "OAuthException",
+                "code": 100,
+                "fbtrace_id": "test123",
+            }
+        }
+
+        with patch("httpx.AsyncClient.post", new_callable=AsyncMock) as mock_post:
+            mock_post.return_value = mock_error_response
+
+            # Act & Assert
+            with pytest.raises(WhatsAppAPIError) as exc_info:
+                await client.send_text_message(
+                    to="invalid",
+                    text="Test",
+                )
+
+            assert "Invalid phone number" in str(exc_info.value)
+
+    async def test_raises_rate_limit_error_after_max_retries(
+        self, client: WhatsAppClient
+    ) -> None:
+        """Should raise WhatsAppRateLimitError after max retries."""
+        # Arrange
+        mock_rate_limit_response = Mock()
+        mock_rate_limit_response.status_code = 429
+        mock_rate_limit_response.json.return_value = {
+            "error": {
+                "message": "Too Many Requests",
+                "type": "OAuthException",
+                "code": 4,
+            }
+        }
+
+        with patch("httpx.AsyncClient.post", new_callable=AsyncMock) as mock_post:
+            # Always return 429
+            mock_post.return_value = mock_rate_limit_response
+
+            with patch("asyncio.sleep", new_callable=AsyncMock):
+                # Act & Assert
+                with pytest.raises(WhatsAppRateLimitError) as exc_info:
+                    await client.send_text_message(
+                        to="+447911123456",
+                        text="Test",
+                    )
+
+                assert "Too Many Requests" in str(exc_info.value)
+                # Should have retried max_retries times (default 3)
+                assert mock_post.call_count == 4  # Initial + 3 retries
+
+    async def test_handles_media_url_fetch_error(self, client: WhatsAppClient) -> None:
+        """Should raise WhatsAppMediaError if getting media URL fails."""
+        # Arrange
+        mock_error_response = Mock()
+        mock_error_response.status_code = 404
+
+        with patch("httpx.AsyncClient.get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = mock_error_response
+
+            # Act & Assert
+            with pytest.raises(WhatsAppMediaError) as exc_info:
+                await client.download_media("invalid_media_id")
+
+            assert "Failed to get media URL: 404" in str(exc_info.value)
+
+    async def test_handles_media_download_error(self, client: WhatsAppClient) -> None:
+        """Should raise WhatsAppMediaError if downloading media content fails."""
+        # Arrange
+        mock_url_response = Mock()
+        mock_url_response.status_code = 200
+        mock_url_response.json.return_value = {
+            "url": "https://media.example.com/file.jpg"
+        }
+
+        mock_download_response = Mock()
+        mock_download_response.status_code = 500
+
+        with patch("httpx.AsyncClient.get", new_callable=AsyncMock) as mock_get:
+            mock_get.side_effect = [mock_url_response, mock_download_response]
+
+            # Act & Assert
+            with pytest.raises(WhatsAppMediaError) as exc_info:
+                await client.download_media("media123")
+
+            assert "Failed to download media: 500" in str(exc_info.value)
+
+    async def test_handles_http_error_during_media_download(
+        self, client: WhatsAppClient
+    ) -> None:
+        """Should raise WhatsAppMediaError on HTTP errors."""
+        # Arrange
+        with patch("httpx.AsyncClient.get", new_callable=AsyncMock) as mock_get:
+            mock_get.side_effect = httpx.ConnectError("Connection failed")
+
+            # Act & Assert
+            with pytest.raises(WhatsAppMediaError) as exc_info:
+                await client.download_media("media123")
+
+            assert "HTTP error downloading media" in str(exc_info.value)
+
+    async def test_handles_invalid_media_response(self, client: WhatsAppClient) -> None:
+        """Should raise WhatsAppMediaError if media response is invalid."""
+        # Arrange
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"invalid": "response"}  # Missing "url" key
+
+        with patch("httpx.AsyncClient.get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = mock_response
+
+            # Act & Assert
+            with pytest.raises(WhatsAppMediaError) as exc_info:
+                await client.download_media("media123")
+
+            assert "Invalid media response" in str(exc_info.value)


### PR DESCRIPTION
## Summary

Implements async WhatsApp Business Cloud API client with exponential backoff retry logic for rate limiting.

- ✅ Send text messages to WhatsApp users
- ✅ Send template messages with variables
- ✅ Send images with optional captions
- ✅ Download media from WhatsApp (2-step process)
- ✅ Exponential backoff retry (1s, 2s, 4s) for 429 rate limit errors
- ✅ Comprehensive error handling with custom exceptions
- ✅ Full type safety with mypy compliance

## Technical Details

- Uses `httpx.AsyncClient` for non-blocking I/O
- WhatsApp Graph API v21.0
- Custom exception hierarchy (`WhatsAppError`, `WhatsAppAPIError`, `WhatsAppRateLimitError`, `WhatsAppMediaError`)
- 88% coverage on WhatsApp client, 98.34% overall
- 11 comprehensive unit tests with mocked HTTP

## Type Safety Improvements

Also includes type safety improvements to existing code:
- Added None checks before SQLAlchemy model attribute access
- Documented SQLAlchemy descriptor pattern type ignores with explanatory comments
- All 190 tests passing with 98.34% coverage

## Test Plan

- [x] Unit tests for all WhatsApp client methods (11 tests)
- [x] Test successful message sending (text, template, image)
- [x] Test media download (2-step process)
- [x] Test retry logic with exponential backoff on 429 errors
- [x] Test error handling (API errors, rate limit exhaustion, media errors)
- [x] MyPy strict type checking passes
- [x] 98.34% test coverage (exceeds 80% requirement)

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)