### PR TITLE
feat: implement in-memory event bus

### DIFF
--- a/docs/is-it-stolen-implementation-guide.md
+++ b/docs/is-it-stolen-implementation-guide.md
@@ -124,8 +124,9 @@ Create `.github/ISSUE_TEMPLATE/feature.md`:
 - ✅ Issue #14: WhatsApp client (REST API client with retry logic)
 - ✅ Issue #15: Webhook handler (parse and validate webhooks with signature verification)
 - ✅ Issue #16: Redis setup (async Redis client with connection pooling)
+- ✅ Issue #17: Event bus (in-memory event bus with async handlers and error handling)
 
-**Current Status**: Milestone 2 Infrastructure - 6/10 complete. Ready to start Issue #17 (Event bus)
+**Current Status**: Milestone 2 Infrastructure - 7/10 complete. Ready to start Issue #18 (Media storage)
 
 ---
 
@@ -302,7 +303,7 @@ Build the infrastructure to support the domain.
 | #14   | WhatsApp client      | REST API client with retry logic    | 4h       | ✅ COMPLETE |
 | #15   | Webhook handler      | Parse and validate webhooks         | 3h       | ✅ COMPLETE |
 | #16   | Redis setup          | Cache and session management        | 2h       | ✅ COMPLETE |
-| #17   | Event bus            | Publish domain events               | 2h       |             |
+| #17   | Event bus            | Publish domain events               | 2h       | ✅ COMPLETE |
 | #18   | Media storage        | Handle images from WhatsApp         | 3h       |             |
 | #19   | Configuration        | Settings with Pydantic              | 1h       |             |
 | #20   | Infrastructure tests | Integration tests                   | 3h       |             |

--- a/src/infrastructure/messaging/__init__.py
+++ b/src/infrastructure/messaging/__init__.py
@@ -1,0 +1,5 @@
+"""Messaging infrastructure for event handling."""
+
+from src.infrastructure.messaging.event_bus import InMemoryEventBus
+
+__all__ = ["InMemoryEventBus"]

--- a/src/infrastructure/messaging/event_bus.py
+++ b/src/infrastructure/messaging/event_bus.py
@@ -1,0 +1,72 @@
+"""Event bus for publishing and subscribing to domain events."""
+
+import logging
+from collections import defaultdict
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+EventHandler = Callable[[Any], Awaitable[None]]
+
+
+class InMemoryEventBus:
+    """In-memory event bus implementation.
+
+    This implementation stores handlers in memory and executes them
+    asynchronously. Failed handlers are logged but don't stop other
+    handlers from executing.
+    """
+
+    def __init__(self) -> None:
+        """Initialize event bus with empty handler registry."""
+        self._handlers: dict[type[Any], list[EventHandler]] = defaultdict(list)
+
+    def subscribe(
+        self,
+        event_type: type[Any],
+        handler: EventHandler,
+    ) -> None:
+        """Subscribe a handler to an event type.
+
+        Args:
+            event_type: Type of event to subscribe to
+            handler: Async handler function to call when event is published
+        """
+        self._handlers[event_type].append(handler)
+
+    def unsubscribe(
+        self,
+        event_type: type[Any],
+        handler: EventHandler,
+    ) -> None:
+        """Unsubscribe a handler from an event type.
+
+        Args:
+            event_type: Type of event to unsubscribe from
+            handler: Handler function to remove
+        """
+        if event_type in self._handlers:
+            self._handlers[event_type].remove(handler)
+
+    async def publish(self, event: Any) -> None:
+        """Publish an event to all subscribed handlers.
+
+        Handlers are executed asynchronously. If a handler fails, the error
+        is logged and other handlers continue to execute.
+
+        Args:
+            event: Domain event to publish
+        """
+        event_type = type(event)
+        handlers = self._handlers.get(event_type, [])
+
+        for handler in handlers:
+            try:
+                await handler(event)
+            except Exception as e:
+                logger.error(
+                    f"Error handling event {event_type.__name__}: {e}",
+                    exc_info=True,
+                )

--- a/tests/unit/infrastructure/test_event_bus.py
+++ b/tests/unit/infrastructure/test_event_bus.py
@@ -1,0 +1,176 @@
+"""Unit tests for event bus."""
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+
+from src.domain.events.domain_events import ItemReported
+from src.domain.value_objects.item_category import ItemCategory
+from src.domain.value_objects.location import Location
+from src.domain.value_objects.phone_number import PhoneNumber
+from src.infrastructure.messaging.event_bus import InMemoryEventBus
+
+
+class TestInMemoryEventBus:
+    """Test in-memory event bus implementation."""
+
+    @pytest.fixture
+    def event_bus(self) -> InMemoryEventBus:
+        """Create event bus for testing."""
+        return InMemoryEventBus()
+
+    async def test_publishes_event_to_single_subscriber(
+        self, event_bus: InMemoryEventBus
+    ) -> None:
+        """Should publish event to registered subscriber."""
+        # Arrange
+        handler = AsyncMock()
+        event_bus.subscribe(ItemReported, handler)
+
+        event = ItemReported(
+            report_id=uuid4(),
+            reporter_phone=PhoneNumber("+27123456789"),
+            item_type=ItemCategory.BICYCLE,
+            description="Red mountain bike",
+            stolen_date=datetime.now(UTC),
+            location=Location(latitude=-33.9249, longitude=18.4241),
+        )
+
+        # Act
+        await event_bus.publish(event)
+
+        # Assert
+        handler.assert_called_once_with(event)
+
+    async def test_publishes_event_to_multiple_subscribers(
+        self, event_bus: InMemoryEventBus
+    ) -> None:
+        """Should publish event to all registered subscribers."""
+        # Arrange
+        handler1 = AsyncMock()
+        handler2 = AsyncMock()
+        event_bus.subscribe(ItemReported, handler1)
+        event_bus.subscribe(ItemReported, handler2)
+
+        event = ItemReported(
+            report_id=uuid4(),
+            reporter_phone=PhoneNumber("+27123456789"),
+            item_type=ItemCategory.BICYCLE,
+            description="Red mountain bike",
+            stolen_date=datetime.now(UTC),
+            location=Location(latitude=-33.9249, longitude=18.4241),
+        )
+
+        # Act
+        await event_bus.publish(event)
+
+        # Assert
+        handler1.assert_called_once_with(event)
+        handler2.assert_called_once_with(event)
+
+    async def test_does_not_publish_to_unsubscribed_handlers(
+        self, event_bus: InMemoryEventBus
+    ) -> None:
+        """Should not call handlers for different event types."""
+        # Arrange
+        from src.domain.events.domain_events import ItemVerified
+
+        reported_handler = AsyncMock()
+        verified_handler = AsyncMock()
+        event_bus.subscribe(ItemReported, reported_handler)
+        event_bus.subscribe(ItemVerified, verified_handler)
+
+        event = ItemReported(
+            report_id=uuid4(),
+            reporter_phone=PhoneNumber("+27123456789"),
+            item_type=ItemCategory.BICYCLE,
+            description="Red mountain bike",
+            stolen_date=datetime.now(UTC),
+            location=Location(latitude=-33.9249, longitude=18.4241),
+        )
+
+        # Act
+        await event_bus.publish(event)
+
+        # Assert
+        reported_handler.assert_called_once_with(event)
+        verified_handler.assert_not_called()
+
+    async def test_unsubscribe_removes_handler(
+        self, event_bus: InMemoryEventBus
+    ) -> None:
+        """Should not call handler after unsubscribing."""
+        # Arrange
+        handler = AsyncMock()
+        event_bus.subscribe(ItemReported, handler)
+        event_bus.unsubscribe(ItemReported, handler)
+
+        event = ItemReported(
+            report_id=uuid4(),
+            reporter_phone=PhoneNumber("+27123456789"),
+            item_type=ItemCategory.BICYCLE,
+            description="Red mountain bike",
+            stolen_date=datetime.now(UTC),
+            location=Location(latitude=-33.9249, longitude=18.4241),
+        )
+
+        # Act
+        await event_bus.publish(event)
+
+        # Assert
+        handler.assert_not_called()
+
+    async def test_handles_handler_exception_without_stopping_other_handlers(
+        self, event_bus: InMemoryEventBus
+    ) -> None:
+        """Should continue publishing to other handlers when one fails."""
+        # Arrange
+        failing_handler = AsyncMock(side_effect=Exception("Handler failed"))
+        successful_handler = AsyncMock()
+        event_bus.subscribe(ItemReported, failing_handler)
+        event_bus.subscribe(ItemReported, successful_handler)
+
+        event = ItemReported(
+            report_id=uuid4(),
+            reporter_phone=PhoneNumber("+27123456789"),
+            item_type=ItemCategory.BICYCLE,
+            description="Red mountain bike",
+            stolen_date=datetime.now(UTC),
+            location=Location(latitude=-33.9249, longitude=18.4241),
+        )
+
+        # Act
+        await event_bus.publish(event)
+
+        # Assert
+        failing_handler.assert_called_once_with(event)
+        successful_handler.assert_called_once_with(event)
+
+    async def test_publishes_to_no_handlers_without_error(
+        self, event_bus: InMemoryEventBus
+    ) -> None:
+        """Should handle publishing when no handlers are registered."""
+        # Arrange
+        event = ItemReported(
+            report_id=uuid4(),
+            reporter_phone=PhoneNumber("+27123456789"),
+            item_type=ItemCategory.BICYCLE,
+            description="Red mountain bike",
+            stolen_date=datetime.now(UTC),
+            location=Location(latitude=-33.9249, longitude=18.4241),
+        )
+
+        # Act & Assert - Should not raise error
+        await event_bus.publish(event)
+
+    async def test_unsubscribe_non_existent_handler_does_not_raise_error(
+        self, event_bus: InMemoryEventBus
+    ) -> None:
+        """Should handle unsubscribing handler that was never subscribed."""
+        # Arrange
+        handler = AsyncMock()
+
+        # Act & Assert - Should not raise error
+        event_bus.unsubscribe(ItemReported, handler)


### PR DESCRIPTION
## Summary

Implements async event bus for publishing and subscribing to domain events with error isolation and comprehensive handler management.

## Changes

### New Files
- `src/infrastructure/messaging/event_bus.py` - In-memory event bus implementation
- `src/infrastructure/messaging/__init__.py` - Module exports
- `tests/unit/infrastructure/test_event_bus.py` - 7 comprehensive unit tests

### Modified Files
- `docs/is-it-stolen-implementation-guide.md` - Marked Issue #17 as complete

## Features

✅ **Event Bus Core**
- `subscribe(event_type, handler)` - Register async handler for event type
- `unsubscribe(event_type, handler)` - Remove handler from event type
- `publish(event)` - Publish event to all subscribed handlers

✅ **Error Handling**
- Failed handlers logged but don't stop other handlers
- Graceful handling of edge cases (no handlers, non-existent removal)
- Error isolation ensures system resilience

✅ **Technical Implementation**
- Uses `defaultdict` for automatic handler list creation
- Handlers executed asynchronously in sequence
- Exceptions caught and logged without stopping execution
- Type-safe with `typing.Any` for flexibility with frozen dataclasses
- Full MyPy strict compliance

✅ **Testing**
- 100% test coverage (7/7 tests passing)
- Tests for single and multiple subscribers
- Event type isolation verification
- Unsubscribe functionality
- Error handling and isolation
- Edge case handling

## Test Results

```
7 passed, 100% coverage on event_bus.py
MyPy: Success - no issues found
```

## Technical Notes

- In-memory implementation suitable for single-server deployments
- Future: Can extend to Redis Pub/Sub or RabbitMQ for distributed systems
- Async handlers allow for non-blocking event processing
- Error isolation prevents cascading failures

## Checklist

- [x] Tests pass locally
- [x] 100% test coverage achieved
- [x] MyPy type checking passes
- [x] Pre-commit hooks pass
- [x] Documentation updated
- [x] Issue description updated

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)