### PR TITLE
feat: Implement DeleteItem command use case (#26)

### DIFF
--- a/docs/is-it-stolen-implementation-guide.md
+++ b/docs/is-it-stolen-implementation-guide.md
@@ -309,7 +309,7 @@ Build the infrastructure to support the domain.
 | #19   | Configuration        | Settings with Pydantic validation   | 1h       | ✅ COMPLETE |
 | #20   | Infrastructure tests | Redis integration tests             | 3h       | ✅ COMPLETE |
 
-### Milestone 3: Application Layer (Issues #21-30) - Week 3 - 5/10 Complete
+### Milestone 3: Application Layer (Issues #21-30) - Week 3 - 6/10 Complete
 
 Implement use cases that orchestrate the domain.
 
@@ -320,7 +320,7 @@ Implement use cases that orchestrate the domain.
 | #23   | Nearby items query    | Location-based search      | ✅ COMPLETE | 2h       |
 | #24   | Verify item command   | Police report verification | ✅ COMPLETE | 2h       |
 | #25   | List user items query | Get user's reports         | ✅ COMPLETE | 2h       |
-| #26   | Delete item command   | Remove reports             |             | 1h       |
+| #26   | Delete item command   | Remove reports             | ✅ COMPLETE | 1h       |
 | #27   | Update item command   | Edit reports               |             | 2h       |
 | #28   | Notification service  | Send confirmations         |             | 2h       |
 | #29   | Export service        | Generate reports           |             | 2h       |

--- a/src/application/commands/delete_item.py
+++ b/src/application/commands/delete_item.py
@@ -1,0 +1,114 @@
+"""Delete Item command and handler."""
+
+from dataclasses import dataclass
+from uuid import UUID
+
+from src.domain.events.domain_events import ItemDeleted
+from src.domain.exceptions.domain_exceptions import (
+    ItemAlreadyDeletedException,
+    ItemNotFoundError,
+    UnauthorizedDeletionError,
+)
+from src.domain.repositories.stolen_item_repository import IStolenItemRepository
+from src.domain.value_objects.phone_number import PhoneNumber
+from src.infrastructure.messaging.event_bus import InMemoryEventBus
+
+
+@dataclass
+class DeleteItemCommand:
+    """Command to delete a stolen item report.
+
+    This DTO carries all data needed to delete a report from the
+    presentation layer to the application layer.
+    """
+
+    report_id: str
+    deleted_by_phone: str
+    reason: str | None = None
+
+
+class DeleteItemHandler:
+    """Handler for deleting stolen item reports.
+
+    This use case orchestrates the domain logic to soft delete an existing
+    stolen item report, persist it, and publish the ItemDeleted event.
+    """
+
+    def __init__(
+        self,
+        repository: IStolenItemRepository,
+        event_bus: InMemoryEventBus,
+    ) -> None:
+        """Initialize handler with dependencies.
+
+        Args:
+            repository: Repository for persisting stolen items
+            event_bus: Event bus for publishing domain events
+        """
+        self._repository = repository
+        self._event_bus = event_bus
+
+    async def handle(self, command: DeleteItemCommand) -> UUID:
+        """Handle the delete item command.
+
+        Args:
+            command: Command containing deletion details
+
+        Returns:
+            UUID of the deleted report
+
+        Raises:
+            ValueError: If UUID or phone number format is invalid
+            ItemNotFoundError: If item does not exist
+            UnauthorizedDeletionError: If deleter is not the reporter
+            ItemAlreadyDeletedException: If item is already deleted
+        """
+        # Parse and validate inputs
+        report_id = self._parse_uuid(command.report_id)
+        deleted_by = PhoneNumber(command.deleted_by_phone)
+
+        # Retrieve item
+        item = await self._repository.find_by_id(report_id)
+        if item is None:
+            raise ItemNotFoundError(f"Item with ID {report_id} not found")
+
+        # Authorization check - only reporter can delete
+        if item.reporter_phone.value != deleted_by.value:
+            raise UnauthorizedDeletionError("Only the reporter can delete the item")
+
+        # Check if already deleted
+        try:
+            item.mark_as_deleted()
+        except ValueError as e:
+            raise ItemAlreadyDeletedException(str(e)) from e
+
+        # Persist the updated item
+        await self._repository.save(item)
+
+        # Publish domain event
+        event = ItemDeleted(
+            report_id=item.report_id,
+            deleted_by=deleted_by,
+            reason=command.reason,
+        )
+        await self._event_bus.publish(event)
+
+        return item.report_id
+
+    @staticmethod
+    def _parse_uuid(uuid_str: str) -> UUID:
+        """Parse UUID string.
+
+        Args:
+            uuid_str: UUID as string
+
+        Returns:
+            UUID object
+
+        Raises:
+            ValueError: If UUID format is invalid
+        """
+        try:
+            return UUID(uuid_str)
+        except (ValueError, AttributeError) as e:
+            raise ValueError(f"Invalid UUID format: {uuid_str}") from e

--- a/src/domain/entities/stolen_item.py
+++ b/src/domain/entities/stolen_item.py
@@ -18,6 +18,7 @@ class ItemStatus(str, Enum):
     ACTIVE = "active"
     RECOVERED = "recovered"
     EXPIRED = "expired"
+    DELETED = "deleted"
 
 
 class StolenItem:
@@ -175,4 +176,19 @@ class StolenItem:
             raise ValueError("Item is already recovered")
 
         self.status = ItemStatus.RECOVERED
+        self.updated_at = datetime.now(UTC)
+
+    def mark_as_deleted(self) -> None:
+        """Mark the item as deleted (soft delete).
+
+        This performs a soft delete by changing the status to DELETED
+        while preserving the record in the database for audit trail.
+
+        Raises:
+            ValueError: If item is already deleted
+        """
+        if self.status == ItemStatus.DELETED:
+            raise ValueError("Item is already deleted")
+
+        self.status = ItemStatus.DELETED
         self.updated_at = datetime.now(UTC)

--- a/src/domain/events/domain_events.py
+++ b/src/domain/events/domain_events.py
@@ -67,3 +67,17 @@ class ItemRecovered:
     recovery_notes: str | None = None
     event_id: UUID = field(default_factory=_generate_event_id)
     occurred_at: datetime = field(default_factory=_generate_timestamp)
+
+
+@dataclass(frozen=True)
+class ItemDeleted:
+    """Event raised when a stolen item report is deleted.
+
+    This event captures who deleted the report and when.
+    """
+
+    report_id: UUID
+    deleted_by: PhoneNumber
+    reason: str | None = None
+    event_id: UUID = field(default_factory=_generate_event_id)
+    occurred_at: datetime = field(default_factory=_generate_timestamp)

--- a/src/domain/exceptions/domain_exceptions.py
+++ b/src/domain/exceptions/domain_exceptions.py
@@ -133,6 +133,28 @@ class UnauthorizedVerificationError(DomainError):
         super().__init__(message, code="UNAUTHORIZED_VERIFICATION")
 
 
+class ItemAlreadyDeletedException(DomainError):
+    """Raised when attempting to delete an already deleted item.
+
+    Prevents double deletion and ensures proper error handling.
+    """
+
+    def __init__(self, message: str) -> None:
+        """Initialize with item already deleted error message."""
+        super().__init__(message, code="ITEM_ALREADY_DELETED")
+
+
+class UnauthorizedDeletionError(DomainError):
+    """Raised when user is not authorized to delete an item.
+
+    Only the original reporter can delete their own report.
+    """
+
+    def __init__(self, message: str) -> None:
+        """Initialize with unauthorized deletion error message."""
+        super().__init__(message, code="UNAUTHORIZED_DELETION")
+
+
 class RepositoryError(DomainError):
     """Raised when repository operations fail.
 

--- a/tests/integration/application/test_delete_item_integration.py
+++ b/tests/integration/application/test_delete_item_integration.py
@@ -1,0 +1,228 @@
+"""Integration tests for DeleteItem command with real database."""
+
+from datetime import UTC, datetime
+from uuid import uuid4
+
+import pytest
+
+from src.application.commands.delete_item import DeleteItemCommand, DeleteItemHandler
+from src.domain.entities.stolen_item import ItemStatus, StolenItem
+from src.domain.exceptions.domain_exceptions import (
+    ItemAlreadyDeletedException,
+    ItemNotFoundError,
+    UnauthorizedDeletionError,
+)
+from src.domain.value_objects.item_category import ItemCategory
+from src.domain.value_objects.location import Location
+from src.domain.value_objects.phone_number import PhoneNumber
+from src.infrastructure.messaging.event_bus import InMemoryEventBus
+from src.infrastructure.persistence.database import get_db
+from src.infrastructure.persistence.models import StolenItemModel
+from src.infrastructure.persistence.repositories.postgres_stolen_item_repository import (
+    PostgresStolenItemRepository,
+)
+
+
+class TestDeleteItemIntegration:
+    """Integration tests with real PostgreSQL database."""
+
+    @pytest.fixture(autouse=True)
+    def clear_database(self) -> None:
+        """Clear stolen_items table before each test."""
+        with get_db() as db:
+            db.query(StolenItemModel).delete()
+            db.commit()
+
+    @pytest.fixture
+    def repository(self) -> PostgresStolenItemRepository:
+        """Create real repository instance."""
+        return PostgresStolenItemRepository()
+
+    @pytest.fixture
+    def event_bus(self) -> InMemoryEventBus:
+        """Create real event bus instance."""
+        return InMemoryEventBus()
+
+    @pytest.mark.asyncio
+    async def test_deletes_item_with_real_database(
+        self,
+        repository: PostgresStolenItemRepository,
+        event_bus: InMemoryEventBus,
+    ) -> None:
+        """Should delete item and persist to real database."""
+        # Arrange - create and save an item
+        item = StolenItem(
+            report_id=uuid4(),
+            reporter_phone=PhoneNumber("+27821234567"),
+            item_type=ItemCategory.BICYCLE,
+            description="Red mountain bike",
+            stolen_date=datetime.now(UTC),
+            location=Location(latitude=-33.9249, longitude=18.4241),
+            status=ItemStatus.ACTIVE,
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
+        )
+        await repository.save(item)
+
+        handler = DeleteItemHandler(
+            repository=repository,
+            event_bus=event_bus,
+        )
+
+        command = DeleteItemCommand(
+            report_id=str(item.report_id),
+            deleted_by_phone="+27821234567",
+            reason="Test deletion",
+        )
+
+        # Act
+        result = await handler.handle(command)
+
+        # Assert
+        assert result == item.report_id
+
+        # Verify persisted in database
+        retrieved = await repository.find_by_id(item.report_id)
+        assert retrieved is not None
+        assert retrieved.status == ItemStatus.DELETED
+
+    @pytest.mark.asyncio
+    async def test_prevents_deletion_by_non_reporter(
+        self,
+        repository: PostgresStolenItemRepository,
+        event_bus: InMemoryEventBus,
+    ) -> None:
+        """Should prevent deletion by someone other than reporter."""
+        # Arrange
+        item = StolenItem(
+            report_id=uuid4(),
+            reporter_phone=PhoneNumber("+27821234567"),
+            item_type=ItemCategory.BICYCLE,
+            description="Red mountain bike",
+            stolen_date=datetime.now(UTC),
+            location=Location(latitude=-33.9249, longitude=18.4241),
+            status=ItemStatus.ACTIVE,
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
+        )
+        await repository.save(item)
+
+        handler = DeleteItemHandler(
+            repository=repository,
+            event_bus=event_bus,
+        )
+
+        command = DeleteItemCommand(
+            report_id=str(item.report_id),
+            deleted_by_phone="+27829999999",  # Different phone
+        )
+
+        # Act & Assert
+        with pytest.raises(UnauthorizedDeletionError):
+            await handler.handle(command)
+
+        # Verify not persisted
+        retrieved = await repository.find_by_id(item.report_id)
+        assert retrieved is not None
+        assert retrieved.status == ItemStatus.ACTIVE
+
+    @pytest.mark.asyncio
+    async def test_prevents_double_deletion(
+        self,
+        repository: PostgresStolenItemRepository,
+        event_bus: InMemoryEventBus,
+    ) -> None:
+        """Should prevent deleting an already deleted item."""
+        # Arrange - create and delete an item
+        item = StolenItem(
+            report_id=uuid4(),
+            reporter_phone=PhoneNumber("+27821234567"),
+            item_type=ItemCategory.BICYCLE,
+            description="Red mountain bike",
+            stolen_date=datetime.now(UTC),
+            location=Location(latitude=-33.9249, longitude=18.4241),
+            status=ItemStatus.ACTIVE,
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
+        )
+        await repository.save(item)
+
+        handler = DeleteItemHandler(
+            repository=repository,
+            event_bus=event_bus,
+        )
+
+        command = DeleteItemCommand(
+            report_id=str(item.report_id),
+            deleted_by_phone="+27821234567",
+        )
+
+        # First deletion
+        await handler.handle(command)
+
+        # Act & Assert - second deletion should fail
+        with pytest.raises(ItemAlreadyDeletedException):
+            await handler.handle(command)
+
+    @pytest.mark.asyncio
+    async def test_raises_error_for_nonexistent_item(
+        self,
+        repository: PostgresStolenItemRepository,
+        event_bus: InMemoryEventBus,
+    ) -> None:
+        """Should raise error when item doesn't exist."""
+        # Arrange
+        handler = DeleteItemHandler(
+            repository=repository,
+            event_bus=event_bus,
+        )
+
+        command = DeleteItemCommand(
+            report_id=str(uuid4()),  # Non-existent ID
+            deleted_by_phone="+27821234567",
+        )
+
+        # Act & Assert
+        with pytest.raises(ItemNotFoundError):
+            await handler.handle(command)
+
+    @pytest.mark.asyncio
+    async def test_deletion_preserves_audit_trail(
+        self,
+        repository: PostgresStolenItemRepository,
+        event_bus: InMemoryEventBus,
+    ) -> None:
+        """Should preserve item in database for audit trail (soft delete)."""
+        # Arrange
+        item = StolenItem(
+            report_id=uuid4(),
+            reporter_phone=PhoneNumber("+27821234567"),
+            item_type=ItemCategory.BICYCLE,
+            description="Red mountain bike",
+            stolen_date=datetime.now(UTC),
+            location=Location(latitude=-33.9249, longitude=18.4241),
+            status=ItemStatus.ACTIVE,
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
+        )
+        await repository.save(item)
+
+        handler = DeleteItemHandler(
+            repository=repository,
+            event_bus=event_bus,
+        )
+
+        command = DeleteItemCommand(
+            report_id=str(item.report_id),
+            deleted_by_phone="+27821234567",
+        )
+
+        # Act
+        await handler.handle(command)
+
+        # Assert - item still exists in database, just marked as deleted
+        retrieved = await repository.find_by_id(item.report_id)
+        assert retrieved is not None
+        assert retrieved.status == ItemStatus.DELETED
+        assert retrieved.description == "Red mountain bike"
+        assert retrieved.reporter_phone.value == "+27821234567"

--- a/tests/unit/application/commands/test_delete_item.py
+++ b/tests/unit/application/commands/test_delete_item.py
@@ -1,0 +1,282 @@
+"""Unit tests for DeleteItem command handler."""
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+
+from src.application.commands.delete_item import DeleteItemCommand, DeleteItemHandler
+from src.domain.entities.stolen_item import ItemStatus, StolenItem
+from src.domain.events.domain_events import ItemDeleted
+from src.domain.exceptions.domain_exceptions import (
+    ItemAlreadyDeletedException,
+    ItemNotFoundError,
+    UnauthorizedDeletionError,
+)
+from src.domain.repositories.stolen_item_repository import IStolenItemRepository
+from src.domain.value_objects.item_category import ItemCategory
+from src.domain.value_objects.location import Location
+from src.domain.value_objects.phone_number import PhoneNumber
+from src.infrastructure.messaging.event_bus import InMemoryEventBus
+
+
+@pytest.fixture
+def mock_repository() -> AsyncMock:
+    """Create mock stolen item repository."""
+    repository = AsyncMock(spec=IStolenItemRepository)
+    return repository
+
+
+@pytest.fixture
+def mock_event_bus() -> AsyncMock:
+    """Create mock event bus."""
+    event_bus = AsyncMock(spec=InMemoryEventBus)
+    return event_bus
+
+
+@pytest.fixture
+def handler(
+    mock_repository: AsyncMock,
+    mock_event_bus: AsyncMock,
+) -> DeleteItemHandler:
+    """Create handler instance."""
+    return DeleteItemHandler(
+        repository=mock_repository,
+        event_bus=mock_event_bus,
+    )
+
+
+@pytest.fixture
+def sample_stolen_item() -> StolenItem:
+    """Create a sample stolen item for testing."""
+    return StolenItem(
+        report_id=uuid4(),
+        reporter_phone=PhoneNumber("+27821234567"),
+        item_type=ItemCategory.BICYCLE,
+        description="Red mountain bike",
+        stolen_date=datetime.now(UTC),
+        location=Location(latitude=-33.9249, longitude=18.4241),
+        status=ItemStatus.ACTIVE,
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
+    )
+
+
+@pytest.fixture
+def valid_command(sample_stolen_item: StolenItem) -> DeleteItemCommand:
+    """Create a valid delete item command."""
+    return DeleteItemCommand(
+        report_id=str(sample_stolen_item.report_id),
+        deleted_by_phone="+27821234567",
+        reason="Duplicate report",
+    )
+
+
+class TestDeleteItemCommand:
+    """Test suite for DeleteItemCommand handler."""
+
+    @pytest.mark.asyncio
+    async def test_deletes_item_successfully(
+        self,
+        handler: DeleteItemHandler,
+        valid_command: DeleteItemCommand,
+        sample_stolen_item: StolenItem,
+        mock_repository: AsyncMock,
+        mock_event_bus: AsyncMock,
+    ) -> None:
+        """Should delete item and publish event."""
+        # Arrange
+        mock_repository.find_by_id.return_value = sample_stolen_item
+
+        # Act
+        result = await handler.handle(valid_command)
+
+        # Assert
+        assert result == sample_stolen_item.report_id
+        assert sample_stolen_item.status == ItemStatus.DELETED
+        mock_repository.save.assert_called_once_with(sample_stolen_item)
+        mock_event_bus.publish.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_publishes_item_deleted_event(
+        self,
+        handler: DeleteItemHandler,
+        valid_command: DeleteItemCommand,
+        sample_stolen_item: StolenItem,
+        mock_repository: AsyncMock,
+        mock_event_bus: AsyncMock,
+    ) -> None:
+        """Should publish ItemDeleted event with correct data."""
+        # Arrange
+        mock_repository.find_by_id.return_value = sample_stolen_item
+
+        # Act
+        await handler.handle(valid_command)
+
+        # Assert
+        mock_event_bus.publish.assert_called_once()
+        event = mock_event_bus.publish.call_args[0][0]
+        assert isinstance(event, ItemDeleted)
+        assert event.report_id == sample_stolen_item.report_id
+        assert event.deleted_by.value == "+27821234567"
+        assert event.reason == "Duplicate report"
+
+    @pytest.mark.asyncio
+    async def test_raises_error_when_item_not_found(
+        self,
+        handler: DeleteItemHandler,
+        valid_command: DeleteItemCommand,
+        mock_repository: AsyncMock,
+    ) -> None:
+        """Should raise ItemNotFoundError when item does not exist."""
+        # Arrange
+        mock_repository.find_by_id.return_value = None
+
+        # Act & Assert
+        with pytest.raises(ItemNotFoundError, match="not found"):
+            await handler.handle(valid_command)
+
+    @pytest.mark.asyncio
+    async def test_raises_error_when_not_reporter(
+        self,
+        handler: DeleteItemHandler,
+        sample_stolen_item: StolenItem,
+        mock_repository: AsyncMock,
+    ) -> None:
+        """Should raise UnauthorizedDeletionError when deleter is not reporter."""
+        # Arrange
+        mock_repository.find_by_id.return_value = sample_stolen_item
+        command = DeleteItemCommand(
+            report_id=str(sample_stolen_item.report_id),
+            deleted_by_phone="+27829999999",  # Different phone
+        )
+
+        # Act & Assert
+        with pytest.raises(UnauthorizedDeletionError, match="Only the reporter"):
+            await handler.handle(command)
+
+    @pytest.mark.asyncio
+    async def test_raises_error_when_already_deleted(
+        self,
+        handler: DeleteItemHandler,
+        valid_command: DeleteItemCommand,
+        mock_repository: AsyncMock,
+    ) -> None:
+        """Should raise ItemAlreadyDeletedException when item is already deleted."""
+        # Arrange
+        item = StolenItem(
+            report_id=uuid4(),
+            reporter_phone=PhoneNumber("+27821234567"),
+            item_type=ItemCategory.BICYCLE,
+            description="Red mountain bike",
+            stolen_date=datetime.now(UTC),
+            location=Location(latitude=-33.9249, longitude=18.4241),
+            status=ItemStatus.DELETED,  # Already deleted
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
+        )
+        mock_repository.find_by_id.return_value = item
+
+        # Act & Assert
+        with pytest.raises(ItemAlreadyDeletedException, match="already deleted"):
+            await handler.handle(valid_command)
+
+    @pytest.mark.asyncio
+    async def test_allows_deletion_without_reason(
+        self,
+        handler: DeleteItemHandler,
+        sample_stolen_item: StolenItem,
+        mock_repository: AsyncMock,
+        mock_event_bus: AsyncMock,
+    ) -> None:
+        """Should allow deletion without providing a reason."""
+        # Arrange
+        mock_repository.find_by_id.return_value = sample_stolen_item
+        command = DeleteItemCommand(
+            report_id=str(sample_stolen_item.report_id),
+            deleted_by_phone="+27821234567",
+        )
+
+        # Act
+        result = await handler.handle(command)
+
+        # Assert
+        assert result == sample_stolen_item.report_id
+        mock_event_bus.publish.assert_called_once()
+        event = mock_event_bus.publish.call_args[0][0]
+        assert event.reason is None
+
+    @pytest.mark.asyncio
+    async def test_raises_error_on_invalid_phone_number(
+        self,
+        handler: DeleteItemHandler,
+        sample_stolen_item: StolenItem,
+        mock_repository: AsyncMock,
+    ) -> None:
+        """Should raise error on invalid phone number format."""
+        # Arrange
+        mock_repository.find_by_id.return_value = sample_stolen_item
+        command = DeleteItemCommand(
+            report_id=str(sample_stolen_item.report_id),
+            deleted_by_phone="invalid",  # Invalid phone
+        )
+
+        # Act & Assert
+        with pytest.raises(ValueError):
+            await handler.handle(command)
+
+    @pytest.mark.asyncio
+    async def test_raises_error_on_invalid_uuid(
+        self,
+        handler: DeleteItemHandler,
+        mock_repository: AsyncMock,
+    ) -> None:
+        """Should raise ValueError on invalid UUID format."""
+        # Arrange
+        command = DeleteItemCommand(
+            report_id="not-a-uuid",
+            deleted_by_phone="+27821234567",
+        )
+
+        # Act & Assert
+        with pytest.raises(ValueError, match="Invalid UUID"):
+            await handler.handle(command)
+
+    @pytest.mark.asyncio
+    async def test_updates_item_timestamp(
+        self,
+        handler: DeleteItemHandler,
+        valid_command: DeleteItemCommand,
+        sample_stolen_item: StolenItem,
+        mock_repository: AsyncMock,
+    ) -> None:
+        """Should update item's updated_at timestamp."""
+        # Arrange
+        mock_repository.find_by_id.return_value = sample_stolen_item
+        original_updated_at = sample_stolen_item.updated_at
+
+        # Act
+        await handler.handle(valid_command)
+
+        # Assert
+        assert sample_stolen_item.updated_at > original_updated_at
+
+    @pytest.mark.asyncio
+    async def test_deletion_is_idempotent_raises_error(
+        self,
+        handler: DeleteItemHandler,
+        valid_command: DeleteItemCommand,
+        sample_stolen_item: StolenItem,
+        mock_repository: AsyncMock,
+    ) -> None:
+        """Should raise error on duplicate deletion attempt."""
+        # Arrange
+        mock_repository.find_by_id.return_value = sample_stolen_item
+
+        # Act - first deletion
+        await handler.handle(valid_command)
+
+        # Act & Assert - second deletion should fail
+        with pytest.raises(ItemAlreadyDeletedException):
+            await handler.handle(valid_command)


### PR DESCRIPTION
## Summary

Implements the DeleteItem command use case that allows users to delete their stolen item reports using soft delete to preserve audit trail.

## Changes

### Domain Layer
- **ItemStatus.DELETED**: New status enum value for soft-deleted items
- **ItemDeleted**: Domain event capturing deletion details (report_id, deleted_by, reason)
- **mark_as_deleted()**: Entity method implementing soft delete business logic
- **ItemAlreadyDeletedException**: Exception preventing duplicate deletion
- **UnauthorizedDeletionError**: Exception for unauthorized deletion attempts

### Application Layer
- **DeleteItemCommand** DTO with:
  - `report_id`: UUID of the report to delete
  - `deleted_by_phone`: Phone number of person deleting (must be reporter)
  - `reason`: Optional deletion reason

- **DeleteItemHandler** orchestrating:
  - Input validation (UUID format, phone number)
  - Repository retrieval of item
  - Authorization check (only reporter can delete their own report)
  - Soft delete via entity's mark_as_deleted() method
  - Persistence of updated item
  - Publishing of ItemDeleted domain event

## Test Coverage

### Unit Tests (10 tests, 100% handler coverage)
- ✅ Successful deletion flow
- ✅ ItemDeleted event publishing with correct data
- ✅ Item not found error handling
- ✅ Unauthorized deletion (non-reporter) rejection
- ✅ Already deleted item rejection
- ✅ Deletion without reason support
- ✅ Invalid phone number validation
- ✅ Invalid UUID validation
- ✅ Timestamp updates
- ✅ Idempotency enforcement

### Integration Tests (5 tests)
- ✅ Full deletion workflow with real PostgreSQL
- ✅ Authorization enforcement with real data
- ✅ Double deletion prevention
- ✅ Non-existent item error handling
- ✅ Audit trail preservation (soft delete verification)

## Quality Metrics
- **380 tests passing** (added 15 new tests)
- **89% code coverage** (above 80% requirement)
- **MyPy strict mode**: No issues
- **Ruff linting**: All checks passed
- **100% coverage** on DeleteItemHandler

## Usage Example

```python
from src.application.commands.delete_item import DeleteItemCommand, DeleteItemHandler

# Initialize handler
handler = DeleteItemHandler(
    repository=repository,
    event_bus=event_bus,
)

# Delete an item
command = DeleteItemCommand(
    report_id="550e8400-e29b-41d4-a716-446655440000",
    deleted_by_phone="+27821234567",
    reason="Duplicate report",  # Optional
)

# Execute
report_id = await handler.handle(command)
```

## Key Features
1. **Soft Delete**: Items marked as DELETED, preserved in database for audit
2. **Authorization**: Only the original reporter can delete their report
3. **Idempotency**: Items can only be deleted once
4. **Audit Trail**: Full record preserved for compliance and investigations
5. **Optional Reason**: Support for tracking why reports were deleted

## Business Rules Enforced
1. **Authorization**: Only the original reporter can delete their report
2. **Idempotency**: Items can only be deleted once
3. **Audit Preservation**: Soft delete maintains full record in database
4. **Status Change**: Status changes from ACTIVE/RECOVERED to DELETED

## Acceptance Criteria
- [x] Accepts report ID and requester phone
- [x] Validates requester is the reporter (authorization)
- [x] Soft delete (mark as deleted, don't remove from DB)
- [x] Publishes ItemDeleted event
- [x] Returns confirmation
- [x] 100% test coverage
- [x] Full type annotations
- [x] Authorization checks
- [x] Audit trail preserved

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>