### PR TITLE
feat: add WhatsApp location message support and enhanced dev logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,6 +95,11 @@ media/
 # Ngrok
 ngrok.log
 
+# SSL Certificates (local development)
+infra/certs/*.key
+infra/certs/*.crt
+infra/certs/*.csr
+
 # Jupyter Notebook
 .ipynb_checkpoints
 

--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,11 @@ clean: ## Clean up generated files
 run: ## Run the application locally
 	$(UVICORN) src.presentation.api.app:app --reload --host 0.0.0.0 --port 8000
 
+run-https: ## Run the application locally with HTTPS
+	$(UVICORN) src.presentation.api.app:app --reload --host 0.0.0.0 --port 8000 \
+		--ssl-keyfile infra/certs/dev.key \
+		--ssl-certfile infra/certs/dev.crt
+
 run-prod: ## Run the application in production mode
 	$(UVICORN) src.presentation.api.app:app --host 0.0.0.0 --port 8000 --workers 4
 

--- a/infra/certs/localhost.conf
+++ b/infra/certs/localhost.conf
@@ -1,0 +1,25 @@
+[req]
+default_bits = 2048
+prompt = no
+default_md = sha256
+distinguished_name = dn
+req_extensions = v3_req
+
+[dn]
+C=ZA
+ST=Gauteng
+L=Johannesburg
+O=Development
+OU=TeeSync
+CN=localhost
+
+[v3_req]
+basicConstraints = CA:FALSE
+keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+subjectAltName = @alt_names
+
+[alt_names]
+DNS.1 = localhost
+DNS.2 = *.localhost
+IP.1 = 127.0.0.1
+IP.2 = ::1

--- a/src/infrastructure/whatsapp/webhook_handler.py
+++ b/src/infrastructure/whatsapp/webhook_handler.py
@@ -19,6 +19,10 @@ class ParsedMessage(TypedDict, total=False):
     text: str
     media_id: str
     mime_type: str
+    latitude: str
+    longitude: str
+    location_name: str
+    location_address: str
 
 
 def verify_webhook_signature(
@@ -246,6 +250,8 @@ class WebhookHandler:
             self._add_text_content(msg, parsed)
         elif msg_type in ("image", "video", "document", "audio"):
             self._add_media_content(msg, msg_type, parsed)
+        elif msg_type == "location":
+            self._add_location_content(msg, parsed)
 
     def _add_text_content(self, msg: dict[str, object], parsed: dict[str, str]) -> None:
         """Add text content to parsed message.
@@ -283,3 +289,34 @@ class WebhookHandler:
         mime_type = media_data.get("mime_type")
         if isinstance(mime_type, str):
             parsed["mime_type"] = mime_type
+
+    def _add_location_content(
+        self, msg: dict[str, object], parsed: dict[str, str]
+    ) -> None:
+        """Add location content to parsed message.
+
+        Args:
+            msg: Message dictionary
+            parsed: Parsed message dict to update
+        """
+        location_data = msg.get("location", {})
+        if not isinstance(location_data, dict):
+            return
+
+        latitude = location_data.get("latitude")
+        longitude = location_data.get("longitude")
+
+        if isinstance(latitude, (int, float)):
+            parsed["latitude"] = str(latitude)
+
+        if isinstance(longitude, (int, float)):
+            parsed["longitude"] = str(longitude)
+
+        # Optional fields
+        location_name = location_data.get("name")
+        if isinstance(location_name, str):
+            parsed["location_name"] = location_name
+
+        location_address = location_data.get("address")
+        if isinstance(location_address, str):
+            parsed["location_address"] = location_address


### PR DESCRIPTION
## Summary

Implements support for WhatsApp location messages in the webhook handler and adds comprehensive debug logging for development environments.

## Changes

### Location Message Support ✅
- ✅ Parse location messages from WhatsApp webhooks (latitude, longitude, name, address)
- ✅ Handle both required (coordinates) and optional (name, address) fields
- ✅ Convert location messages to text representation for processing
- ✅ Skip location messages missing coordinates with proper warnings

### Enhanced Development Logging ✅
- ✅ Add debug logging for incoming webhook payloads in dev/test environments
- ✅ Add debug logging for each message being processed with metadata
- ✅ Add info logging for location messages with coordinates
- ✅ Fix logging conflicts by avoiding reserved field names (message, name)
- ✅ Add `pragma: no cover` for unreachable defensive code

### Infrastructure Updates ✅
- ✅ Add SSL certificate patterns to `.gitignore` (*.key, *.crt, *.csr)
- ✅ Add `run-https` command to Makefile for local HTTPS development
- ✅ Add localhost.conf for SSL certificate configuration

### Test Coverage ✅
- ✅ Add 8 comprehensive tests for location message parsing in webhook_handler
- ✅ Add 7 tests for location message handling at webhook endpoint level
- ✅ Add test for debug logging in dev environment
- ✅ Achieve 100% coverage on webhook.py (was 94%)
- ✅ All 55 webhook tests passing

## Test Results

```bash
============================= test session starts ==============================
collected 55 items

tests/unit/infrastructure/test_webhook_handler.py ...................... [ 40%]
...........                                                              [ 60%]
tests/unit/presentation/test_webhook.py ......................           [100%]

============================== 55 passed in 0.23s ==============================
```

## Coverage Report

```
src/presentation/api/v1/webhook.py    75      0     18      0   100%
```

## How to Test

1. **Location message parsing:**
   ```bash
   poetry run pytest tests/unit/infrastructure/test_webhook_handler.py::TestWebhookPayloadParsing::test_parses_location_message -v
   ```

2. **Location message handling:**
   ```bash
   poetry run pytest tests/unit/presentation/test_webhook.py::TestWebhookLocationMessages -v
   ```

3. **All webhook tests:**
   ```bash
   poetry run pytest tests/unit/infrastructure/test_webhook_handler.py tests/unit/presentation/test_webhook.py -v
   ```

Closes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>